### PR TITLE
fix: navigator is not defined cause by firebase.analytics()

### DIFF
--- a/plugins/firebase.js
+++ b/plugins/firebase.js
@@ -25,7 +25,9 @@ if (!firebase.apps.length) {
   firebase.auth();
   firebase.firestore();
   firebase.storage();
-  firebase.analytics();
+  if (process.browser) {
+    firebase.analytics();
+  }
 }
 
 export default firebase;


### PR DESCRIPTION
# issue #104  done 
Next.js(Nuxt.jsも同様)はサーバサイドでも同じコードが走るので、window.navigatorなど、ブラウザにしかないオブジェクトにアクセスする際は、**クライアント側のみで処理が走るようにする**必要があります。
_参考にしたサイト_
_[https://blog.kimizuka.org/entry/2021/02/26/195833](url)_