### PR TITLE
ポインターを修正

### DIFF
--- a/components/Organisms/SearchPlace.vue
+++ b/components/Organisms/SearchPlace.vue
@@ -41,7 +41,7 @@
                       class="pa-0 ma-0"
                       @click="toPlaceDetail(item)"
                     >
-                      <v-card nuxt outlined tile :elevation="2">
+                      <v-card class="place-card" nuxt outlined tile :elevation="2">
                         <v-card-title class="pa-2">{{ item.name }}</v-card-title>
                         <div class="px-1 pt-1">
                           <rating
@@ -164,6 +164,9 @@ export default {
   max-width: 95vw;
   max-height: 240px;
   margin: auto;
+}
+.place-card {
+  cursor: pointer;
 }
 
 @media only screen and (max-device-width: 550px) {

--- a/components/Organisms/WisdomThread.vue
+++ b/components/Organisms/WisdomThread.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0">
-    <v-row no-gutters>
+    <v-row class="posted-wisdom-card" no-gutters>
       <v-col class="pa-0" cols="12">
         <v-divider></v-divider>
         <v-card tile elevation="0">
@@ -173,6 +173,9 @@ export default {
 };
 </script>
 <style scoped>
+.posted-wisdom-card {
+  cursor: pointer;
+}
 .posted-wisdoms-title {
   margin: 16px 0;
   text-align: center;

--- a/pages/timeline/article/detailArticle.vue
+++ b/pages/timeline/article/detailArticle.vue
@@ -33,10 +33,10 @@
           </v-list>
           <v-list class="mb-4">
             <v-list-item>
-              <v-list-item-avatar>
+              <v-list-item-avatar class="article-author-icon">
                 <img :src="authorIcon" @click="toAuthorArticle" />
               </v-list-item-avatar>
-              <v-list-item-content @click="toAuthorArticle">
+              <v-list-item-content class="article-author-name" @click="toAuthorArticle">
                 <v-list-item-title>{{ authorName }}</v-list-item-title>
                 <v-list-item-subtitle class="to-author">著者関連記事へ</v-list-item-subtitle>
               </v-list-item-content>
@@ -408,5 +408,11 @@ export default {
 }
 .post-button {
   text-align: center;
+}
+.article-author-icon {
+  cursor: pointer;
+}
+.article-author-name {
+  cursor: pointer;
 }
 </style>

--- a/pages/timeline/event/detailEvent.vue
+++ b/pages/timeline/event/detailEvent.vue
@@ -505,6 +505,7 @@ export default {
 .content-url {
   color: #00f;
   text-decoration: underline;
+  cursor: pointer;
 }
 .post-button {
   text-align: center;

--- a/pages/timeline/job/detailJob.vue
+++ b/pages/timeline/job/detailJob.vue
@@ -94,9 +94,11 @@
                 <v-list-item-content class="font-weight-black">公式HP</v-list-item-content>
               </v-list-item>
               <v-list-item>
-                <v-list-item-content class="text-subtitle-2" @click="toLink(jobDetailObject.hp)">{{
-                  jobDetailObject.hp
-                }}</v-list-item-content>
+                <v-list-item-content
+                  class="text-subtitle-2 content-url"
+                  @click="toLink(jobDetailObject.hp)"
+                  >{{ jobDetailObject.hp }}</v-list-item-content
+                >
               </v-list-item>
             </div>
             <div v-if="jobDetailObject.secret">
@@ -427,6 +429,7 @@ export default {
 .content-url {
   color: #00f;
   text-decoration: underline;
+  cursor: pointer;
 }
 .edit-button {
   float: right;

--- a/pages/timeline/review/detailReview.vue
+++ b/pages/timeline/review/detailReview.vue
@@ -19,7 +19,7 @@
               </v-col>
             </v-row>
             <v-row align-content="center">
-              <v-col cclass="pl-5 pr-0" cols="7">
+              <v-col class="pl-5 pr-0 place-name" cols="7">
                 <v-card-title
                   class="pa-0"
                   style="color: #1976d2"
@@ -415,5 +415,8 @@ export default {
 }
 .buttom-button-bar {
   background-color: rgba(255, 255, 255, 0.6);
+}
+.place-name {
+  cursor: pointer;
 }
 </style>

--- a/pages/timetable/classDetail.vue
+++ b/pages/timetable/classDetail.vue
@@ -429,6 +429,7 @@ export default {
   right: 2.1vh;
   font-size: 1rem;
   color: #717171;
+  cursor: pointer;
 }
 .counters-wrapper {
   display: flex;

--- a/pages/timetable/index.vue
+++ b/pages/timetable/index.vue
@@ -46,6 +46,7 @@
                     v-for="day in weekNames"
                     :key="day"
                     :style="{ background: data[day].color }"
+                    class="timetable-square"
                     @click="detail(data[day], index, day)"
                   >
                     <span class="classTitle">
@@ -295,5 +296,8 @@ table td {
 .bound-leave-to {
   transform: scale(0.9);
   opacity: 0;
+}
+.timetable-square {
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
close #147 

新しいブランチで作業したため、再度プルリクします。
ポインターを再度修正しました。変更箇所は以下の通りです。 
・タイムライン上の知恵袋のカード 
・クチコミ詳細ページの店名 
・学生記事詳細ページの著者関連記事へ 
・イベント詳細ページのURL 
・アルバイト詳細ページのURL 
・検索画面のカード 
・時間割のマス目 
 
以上のカーソルをポインターに変更しました。ご確認よろしくお願いします。