### PR TITLE
タイムライン上のアルバイト表示条件の変更

### DIFF
--- a/store/job.js
+++ b/store/job.js
@@ -17,6 +17,7 @@ export const getters = {
     return state.geometry;
   },
   recruitArray(state) {
+    console.log('aa' + state.recruitArray);
     return state.recruitArray;
   },
   recruitDetail(state) {
@@ -53,62 +54,65 @@ export const mutations = {
 };
 export const actions = {
   async getRecruitArray({ commit }) {
-    await recruitdb.where('isPublic', '==', true).onSnapshot((snapshot) => {
-      snapshot.docChanges().forEach((change) => {
-        if (change.type === 'added') {
-          const recruit = change.doc.data();
-          const postedRecruit = {
-            id: change.doc.id,
-            img: recruit.img,
-            genre: recruit.genre,
-            placeName: recruit.placeName,
-            money: recruit.money,
-            remark: recruit.remark,
-            geometry: recruit.geometry,
-            startTime1: recruit.startTime1,
-            endTime1: recruit.endTime1,
-            startTime2: recruit.startTime2,
-            endTime2: recruit.endTime2,
-            startTime3: recruit.startTime3,
-            endTime3: recruit.endTime3,
-            isPublic: recruit.isPublic,
-            poster: recruit.uid,
-            contactEmail: recruit.contactEmail,
-            contactPhone: recruit.contactPhone,
-            contactRemark: recruit.contactRemark,
-            date: change.doc.data({ serverTimestamps: 'estimate' }).createdAt.toDate(),
-          };
-          commit('setRecruitArray', { payload: postedRecruit, target: change.newIndex });
-        } else if (change.type === 'modified') {
-          const recruit = change.doc.data();
-          const modifiedRecruit = {
-            id: change.doc.id,
-            img: recruit.img,
-            genre: recruit.genre,
-            placeName: recruit.placeName,
-            money: recruit.money,
-            remark: recruit.remark,
-            geometry: recruit.geometry,
-            startTime1: recruit.startTime1,
-            endTime1: recruit.endTime1,
-            startTime2: recruit.startTime2,
-            endTime2: recruit.endTime2,
-            startTime3: recruit.startTime3,
-            endTime3: recruit.endTime3,
-            isPublic: recruit.isPublic,
-            poster: recruit.uid,
-            contactEmail: recruit.contactEmail,
-            contactPhone: recruit.contactPhone,
-            contactRemark: recruit.contactRemark,
+    await recruitdb
+      .where('isConfirmed', '==', true)
+      .where('isPublic', '==', true)
+      .onSnapshot((snapshot) => {
+        snapshot.docChanges().forEach((change) => {
+          if (change.type === 'added') {
+            const recruit = change.doc.data();
+            const postedRecruit = {
+              id: change.doc.id,
+              img: recruit.img,
+              genre: recruit.genre,
+              placeName: recruit.placeName,
+              money: recruit.money,
+              remark: recruit.remark,
+              geometry: recruit.geometry,
+              startTime1: recruit.startTime1,
+              endTime1: recruit.endTime1,
+              startTime2: recruit.startTime2,
+              endTime2: recruit.endTime2,
+              startTime3: recruit.startTime3,
+              endTime3: recruit.endTime3,
+              isPublic: recruit.isPublic,
+              poster: recruit.uid,
+              contactEmail: recruit.contactEmail,
+              contactPhone: recruit.contactPhone,
+              contactRemark: recruit.contactRemark,
+              date: change.doc.data({ serverTimestamps: 'estimate' }).createdAt.toDate(),
+            };
+            commit('setRecruitArray', { payload: postedRecruit, target: change.newIndex });
+          } else if (change.type === 'modified') {
+            const recruit = change.doc.data();
+            const modifiedRecruit = {
+              id: change.doc.id,
+              img: recruit.img,
+              genre: recruit.genre,
+              placeName: recruit.placeName,
+              money: recruit.money,
+              remark: recruit.remark,
+              geometry: recruit.geometry,
+              startTime1: recruit.startTime1,
+              endTime1: recruit.endTime1,
+              startTime2: recruit.startTime2,
+              endTime2: recruit.endTime2,
+              startTime3: recruit.startTime3,
+              endTime3: recruit.endTime3,
+              isPublic: recruit.isPublic,
+              poster: recruit.uid,
+              contactEmail: recruit.contactEmail,
+              contactPhone: recruit.contactPhone,
+              contactRemark: recruit.contactRemark,
 
-            date: change.doc.data({ serverTimestamps: 'estimate' }).createdAt.toDate(),
-          };
-          commit('modifyRecruitArray', { payload: modifiedRecruit, target: change.newIndex });
-        } else if (change.type === 'removed') {
-          commit('removeRecruitArray', { target: change.oldIndex });
-        }
+              date: change.doc.data({ serverTimestamps: 'estimate' }).createdAt.toDate(),
+            };
+            commit('modifyRecruitArray', { payload: modifiedRecruit, target: change.newIndex });
+          } else if (change.type === 'removed') {
+            commit('removeRecruitArray', { target: change.oldIndex });
+          }
+        });
       });
-    });
   },
   async getRecruitDetail({ commit }, payload) {
     await recruitdb

--- a/store/job.js
+++ b/store/job.js
@@ -17,7 +17,6 @@ export const getters = {
     return state.geometry;
   },
   recruitArray(state) {
-    console.log('aa' + state.recruitArray);
     return state.recruitArray;
   },
   recruitDetail(state) {


### PR DESCRIPTION
タイムラインのアルバイトについて、運営側の確認が取れた状態の求人情報のみ表示に変更しました。
そのため、以下2つの変数で表示・非表示を管理します。

1. isConfirmed：運営側が確認済みか
2. isPublic：掲載元(企業)が公開したいか

双方がtrueだった場合のみ表示されます。1→2の順に影響度が高いため、1がfalseの場合は2がtrueでも表示されない仕様になっています。

ご確認よろしくお願いします。